### PR TITLE
Added a default (lldb) attach option for macOS users on apple silicon.

### DIFF
--- a/src/pythonCppDebug.ts
+++ b/src/pythonCppDebug.ts
@@ -209,6 +209,23 @@ export class PythonCppDebugSession extends LoggingDebugSession {
 				]
 			};
 		}
+		else if(config.cppConfig === "default (lldb) Attach"){
+			cppAttach = {
+				"name": "(lldb) Attach",
+				"type": "cppdbg",
+				"request": "attach",
+				"program": await getPythonPath(null),
+				"processId": "",
+				"MIMode": "lldb",
+				"setupCommands": [
+					{
+						"description": "Enable pretty-printing for gdb",
+						"text": "-enable-pretty-printing",
+						"ignoreFailures": true
+					}
+				]
+			};
+		}
 
 		config.pythonLaunch = pythonLaunch;
 		config.cppAttach = cppAttach;


### PR DESCRIPTION
Adds a default option for using lldb at the debugger for macOS users on apple silicon (gdb is not available from homebrew except on x86 macs).

Drop in replacement for the currently available: ```default (win) Attach``` and ```default (gdb) Attach```